### PR TITLE
made protobuf build scripts portable

### DIFF
--- a/build-go-proto.sh
+++ b/build-go-proto.sh
@@ -1,13 +1,13 @@
-
-#!/bin/sh
+#!/bin/bash
 #
 # See:
-#    plan-systems/plan-protobuf/README.md 
+#    plan-systems/plan-protobuf/README.md
 #    http://plan-systems.org
 #
 #
+set -e
 
-SELF=`basename "$0"`
+SELF=$(basename "$0")
 
 if [[ $# -ne 2 ]]; then
     echo "Usage: ./build-go-proto.sh <plan_pkg_name> <out_path>"
@@ -18,17 +18,17 @@ PKG_NAME="$1"
 DST_DIR="$2"
 
 BUILD_PROTO="../plan-protobufs/build-proto.sh"
-
-replace='s/#PKG# \"#PKG#\"/#PKG# \"github.com\/plan-systems\/plan-core\/#PKG#\" \/\/\/ Redirected by '$SELF' :)/' 
-
-#echo "$replace"
-#echo "${replace//#PKG#/plan}"
-
 $BUILD_PROTO "$PKG_NAME" gofast "$DST_DIR"
-sed -i ''	-e "${replace//#PKG#/plan}" 	\
-			-e "${replace//#PKG#/ski}"		\
-			-e "${replace//#PKG#/client}"   \
-			-e "${replace//#PKG#/pdi}"		\
-			-e "${replace//#PKG#/repo}" 	\
-			"$DST_DIR/$PKG_NAME/$PKG_NAME.pb.go"
 
+# we need the canonical go import path, so edit the generated file
+replace='s~#PKG# "#PKG#"~#PKG# "github.com/plan-systems/plan-core" /// Redirected by '$SELF' :)~'
+
+echo "$DST_DIR/$PKG_NAME/$PKG_NAME.pb.go"
+
+sed -i'' \
+    -e "${replace//#PKG#/plan}" 	\
+    -e "${replace//#PKG#/ski}"		\
+    -e "${replace//#PKG#/client}"   \
+    -e "${replace//#PKG#/pdi}"		\
+    -e "${replace//#PKG#/repo}" 	\
+    "$DST_DIR/$PKG_NAME/$PKG_NAME.pb.go"

--- a/build-protobufs.sh
+++ b/build-protobufs.sh
@@ -1,12 +1,11 @@
-
-#!/bin/sh
+#!/bin/bash
 #
 # See:
-#    plan-systems/plan-protobuf/README.md 
+#    plan-systems/plan-protobuf/README.md
 #    http://plan-systems.org
 #
 #
-
+set -e
 
 SELF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
@@ -14,11 +13,11 @@ BUILD_GO_ROTO="./build-go-proto.sh"
 
 
 PKGS=(
-    "plan" 
-    "ski" 
+    "plan"
+    "ski"
     "pdi"
     "repo"
-	"client"
+    "client"
 )
 NUM_PKGS=$(( ${#PKGS[@]} ))
 
@@ -35,4 +34,3 @@ do
 	$BUILD_GO_ROTO "$PKG" "$DST_DIR"
 
 done
-


### PR DESCRIPTION
- fixed interpreter directive to match bashism in use
- sed: made in-place edit portable between BSD and GNU sed
- sed: reduced escaping complexity by using ~ as delimiter
- shellcheck: mostly quoting fixes
- added halt-on-error directive
