### PR TITLE
fixes sed portability

### DIFF
--- a/build-go-proto.sh
+++ b/build-go-proto.sh
@@ -21,16 +21,17 @@ BUILD_PROTO="../plan-protobufs/build-proto.sh"
 $BUILD_PROTO "$PKG_NAME" gofast "$DST_DIR"
 
 # we need the canonical go import path, so edit the generated file
-replace='s~#PKG# "#PKG#"~#PKG# "github.com/plan-systems/plan-core/#PKG#" /// Redirected by '$SELF' :)~' 
+replace='s~#PKG# "#PKG#"~#PKG# "github.com/plan-systems/plan-core/#PKG#" /// Redirected by '$SELF' :)~'
 
 output_file="$DST_DIR/$PKG_NAME/$PKG_NAME.pb.go"
 
-sed -i '' \
+sed \
     -e "${replace//#PKG#/plan}" 	\
     -e "${replace//#PKG#/ski}"		\
     -e "${replace//#PKG#/client}"   \
     -e "${replace//#PKG#/pdi}"		\
     -e "${replace//#PKG#/repo}" 	\
-    "$output_file"
+    "$output_file" > "${output_file}.tmp"
+mv "${output_file}.tmp" "$output_file"
 
-echo $output_file
+echo "$output_file"


### PR DESCRIPTION
The -i flag for sed isn't POSIX-compliant, so it's implemented
differently in GNU sed (used by Linux) and BSD sed (used by macOS).
Rather than trying to shoe-horn cross-compatibility, we can just
not use the in-place edit and move the resulting file to its
final location.